### PR TITLE
Fix wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,24 @@ jobs:
       - name: Build
         run: nix build -L .#llvm_${{ matrix.llvm }}.dist
 
+      - name: Repair wheel (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          nix shell .#llvm_${{ matrix.llvm }}.dist nixpkgs#uv nixpkgs#patchelf \
+            --command uvx --with patchelf auditwheel repair --strip result-dist/*.whl -w dist
+
+      - name: Repair wheel (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          nix shell .#llvm_${{ matrix.llvm }}.dist nixpkgs#uv \
+            --command uvx --from delocate delocate-wheel -v -w dist result-dist/*.whl
+
       - name: Upload
         uses: actions/upload-artifact@v7.0.1
         if: ${{ matrix.llvm == 22 }}
         with:
           name: wheel-${{ matrix.os }}
-          path: result-dist/*.whl
+          path: dist/*.whl
 
   build-windows:
     runs-on: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,41 +86,6 @@ jobs:
             -Dcpp_link_args=-static
         run: uv build --wheel --verbose
 
-      # HACK: only necessary for `libzstd.dll` for LLVM 17 and above.
-      - name: Repair Wheel (Copy dependencies)
-        run: |
-          WHEEL_FILE=$(ls dist/*.whl | head -n 1)
-          DLL_PATH=$(uvx delvewheel show "$WHEEL_FILE" --add-path /clang64/bin --include libzstd.dll | grep -oP '\(\K[^)]+')
-
-          if [ -z "$DLL_PATH" ]; then
-            echo "Error: Could not find libzstd.dll path via delvewheel."
-            exit 1
-          fi
-
-          echo "Found DLL at: $DLL_PATH"
-          echo "Targeting wheel: $WHEEL_FILE"
-
-          mkdir -p wheel_contents
-          7z x "$WHEEL_FILE" -owheel_contents
-
-          TARGET_DIR="wheel_contents/vapoursynth/plugins/akarin"
-
-          if [ -d "$TARGET_DIR" ]; then
-            cp "$DLL_PATH" "$TARGET_DIR/"
-            echo "Successfully injected libzstd.dll into $TARGET_DIR"
-          else
-            echo "Error: Target directory $TARGET_DIR not found in wheel."
-            exit 1
-          fi
-
-          rm "$WHEEL_FILE"
-          cd wheel_contents
-          7z a -tzip "../$WHEEL_FILE" *
-          cd ..
-
-          rm -rf wheel_contents
-          echo "Wheel successfully rebuilt without delvewheel init-patch."
-
       - name: Upload
         uses: actions/upload-artifact@v7.0.1
         with:

--- a/README.md
+++ b/README.md
@@ -211,8 +211,8 @@ pip install vapoursynth-akarin
    ```
 
 > [!NOTE]
-> When building with LLVM 17 or newer, the plugin will depend on `libzstd.dll`.
-> You may need to manually copy this DLL from your MSYS2 installation (`/clang64/bin/libzstd.dll`) to the plugin directory if it is not already in your PATH.
+> When building with LLVM 17 or newer, the plugin depends on `libzstd.dll`.
+> The wheel build process (via `uv build`) automatically bundles this DLL from your MSYS2 environment if it is found in your PATH.
 
 ### Linux & macOS
 

--- a/hatch_build.py
+++ b/hatch_build.py
@@ -31,5 +31,22 @@ class CustomHook(BuildHookInterface[Any]):
             if file_path.is_file() and file_path.suffix in [".dll", ".so", ".dylib"]:
                 shutil.copy2(file_path, self.target_dir)
 
+        if sys.platform == "win32":
+            dll_path = shutil.which("libzstd.dll")
+
+            if not dll_path:
+                for prefix in [os.getenv("MSYSTEM_PREFIX"), "C:/msys64/clang64", "C:/msys64/ucrt64"]:
+                    if not prefix:
+                        continue
+                    if (candidate := Path(prefix) / "bin" / "libzstd.dll").exists():
+                        dll_path = candidate
+                        break
+
+            if dll_path:
+                shutil.copy2(dll_path, self.target_dir)
+                print(f"Bundled dependency: {dll_path}", file=sys.stderr)
+            else:
+                print("Warning: Could not find libzstd.dll in PATH or common MSYS2 locations.", file=sys.stderr)
+
     def finalize(self, version: str, build_data: dict[str, Any], artifact_path: str) -> None:
         shutil.rmtree(self.target_dir.parent, ignore_errors=True)


### PR DESCRIPTION
- Windows: Bundle `libzstd.dll` from the hatch hook so the RECORD file matches the actual content.
- Linux: Add repair wheel step to reduce minimum glibc requirement to 2.39
- macOS: Add repair wheel step to bundle the necessary `libz.1.3.2.dylib` file.