### PR TITLE
ci: lower glibc requirement to 2.35, add more supported platforms

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,9 +75,19 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        llvm: [20, 21, 22]
-    name: Build macos llvm=${{ matrix.llvm }}
-    runs-on: macos-15
+        include:
+          - target: macos-26
+            llvm: 20
+          - target: macos-26
+            llvm: 21
+          - target: macos-26
+            llvm: 22
+            artifact: "wheel-macos"
+          - target: macos-26-intel
+            llvm: 22
+            artifact: "wheel-macos-intel"
+    name: Build ${{ matrix.target }} llvm=${{ matrix.llvm }}
+    runs-on: ${{ matrix.target }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6.0.2
@@ -104,7 +114,7 @@ jobs:
         uses: actions/upload-artifact@v7.0.1
         if: ${{ matrix.llvm == 22 }}
         with:
-          name: wheel-macos
+          name: ${{ matrix.artifact }}
           path: dist/*.whl
 
   build-windows:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,14 +11,73 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  build-linux:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-15]
+        include:
+          - target: glibc
+            llvm: 20
+          - target: glibc
+            llvm: 21
+          - target: glibc
+            llvm: 22
+            artifact: "wheel-linux"
+          - target: musl
+            llvm: 22
+            artifact: "wheel-musllinux"
+            container: alpine:edge
+
+    name: Build ${{ matrix.target }} llvm=${{ matrix.llvm }}
+    runs-on: ubuntu-22.04
+    container: ${{ matrix.container }}
+
+    steps:
+      - name: Install LLVM (glibc)
+        if: matrix.target == 'glibc'
+        run: |
+          wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
+          chmod +x /tmp/llvm.sh
+          sudo /tmp/llvm.sh ${{ matrix.llvm }}
+          sudo apt-get install -y --no-install-recommends \
+            llvm-${{ matrix.llvm }}-dev \
+            libxml2-dev \
+            pkg-config
+
+      - name: Install system dependencies (musl)
+        if: matrix.target == 'musl'
+        run: |
+          apk update
+          apk add --no-cache git build-base pkgconf llvm llvm-dev llvm-static libxml2-dev bash curl
+
+      - name: Checkout code
+        uses: actions/checkout@v6.0.2
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Build wheel
+        env:
+          MESON_ARGS: --buildtype release
+        run: uv build --wheel --verbose
+
+      - name: Repair wheel
+        run: uvx --with patchelf auditwheel repair --strip dist/*.whl -w dist-repaired
+
+      - name: Upload
+        uses: actions/upload-artifact@v7.0.1
+        if: ${{ matrix.llvm == 22 }}
+        with:
+          name: ${{ matrix.artifact }}
+          path: dist-repaired/*.whl
+
+  build-macos:
+    strategy:
+      fail-fast: false
+      matrix:
         llvm: [20, 21, 22]
-    name: Build os=${{ matrix.os }} llvm=${{ matrix.llvm }}
-    runs-on: ${{ matrix.os }}
+    name: Build macos llvm=${{ matrix.llvm }}
+    runs-on: macos-15
     steps:
       - name: Checkout code
         uses: actions/checkout@v6.0.2
@@ -36,14 +95,7 @@ jobs:
       - name: Build
         run: nix build -L .#llvm_${{ matrix.llvm }}.dist
 
-      - name: Repair wheel (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          nix shell .#llvm_${{ matrix.llvm }}.dist nixpkgs#uv nixpkgs#patchelf \
-            --command uvx --with patchelf auditwheel repair --strip result-dist/*.whl -w dist
-
-      - name: Repair wheel (macOS)
-        if: runner.os == 'macOS'
+      - name: Repair wheel
         run: |
           nix shell .#llvm_${{ matrix.llvm }}.dist nixpkgs#uv \
             --command uvx --from delocate delocate-wheel -v -w dist result-dist/*.whl
@@ -52,7 +104,7 @@ jobs:
         uses: actions/upload-artifact@v7.0.1
         if: ${{ matrix.llvm == 22 }}
         with:
-          name: wheel-${{ matrix.os }}
+          name: wheel-macos
           path: dist/*.whl
 
   build-windows:
@@ -116,7 +168,7 @@ jobs:
   publish-pypi:
     name: Publish to PyPI
     runs-on: ubuntu-24.04
-    needs: [build, build-windows, build-sdist]
+    needs: [build-linux, build-macos, build-windows, build-sdist]
     if: startsWith(github.ref, 'refs/tags/')
 
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,19 +22,23 @@ jobs:
             llvm: 21
           - target: glibc
             llvm: 22
-            artifact: "wheel-linux"
+            artifact: "wheel-manylinux-x86-64"
+          - target: glibc arm
+            llvm: 22
+            artifact: "wheel-manylinux-aarch64"
+            os: ubuntu-22.04-arm
           - target: musl
             llvm: 22
-            artifact: "wheel-musllinux"
+            artifact: "wheel-musllinux-x86-64"
             container: alpine:edge
 
     name: Build ${{ matrix.target }} llvm=${{ matrix.llvm }}
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.os  || 'ubuntu-22.04' }}
     container: ${{ matrix.container }}
 
     steps:
       - name: Install LLVM (glibc)
-        if: matrix.target == 'glibc'
+        if: startsWith(matrix.target, 'glibc')
         run: |
           wget -qO /tmp/llvm.sh https://apt.llvm.org/llvm.sh
           chmod +x /tmp/llvm.sh
@@ -82,10 +86,10 @@ jobs:
             llvm: 21
           - target: macos-26
             llvm: 22
-            artifact: "wheel-macos"
+            artifact: "wheel-macos-arm64"
           - target: macos-26-intel
             llvm: 22
-            artifact: "wheel-macos-intel"
+            artifact: "wheel-macos-x86_64"
     name: Build ${{ matrix.target }} llvm=${{ matrix.llvm }}
     runs-on: ${{ matrix.target }}
     steps:


### PR DESCRIPTION
- Run the Linux build on ubuntu 22.04 to lower the glibc requirement to 2.35. I couldn't find a way to use nix without compiling the entire LLVM toolchain which took 2 hours on the runners.
- Add manylinux aarch64
- Add musllinux target & macOS intel