### PR TITLE
akarin.Text: Support float precision formatting syntax (e.g. `{MyFrameProp:.4f}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Text is an enhanced `text.Text`:
   - `{N}`: The predefined `N` is the current frame number (if you want to access a frame property named `N`, use the full form `{x.N}` instead.
   - `"Matrix: {x._Matrix}"`: it will show the matrix property in string format (i.e. `Matrix: BT.709`).
   - `"Matrix: {x._Matrix:d}"`: it will show the matrix property as a number.
+  - `"Value: {x.SomeFloat:.4f}"`: it will show a float property with four digits after the decimal point.
   - `"Chroma: {x._ChromaLocation:.>10s}`: it will show the chroma location as a string, right aligned, and padded on the left with '.' (i.e. `Chroma: ......Left`).
 
 The filter supports formatting int/float scalar or arrays, data (shown as string). All the rest are shown as type sepcific placeholders (e.g. `<node>` for a node).

--- a/text/textfilter.cpp
+++ b/text/textfilter.cpp
@@ -323,6 +323,8 @@ struct CustomValue {
     CustomValue(int val, std::string (*fptr)(int)): val(val), fptr(fptr) {}
 };
 
+struct ValidationValue {}; // Accepts format specifications before the property type is known.
+
 struct MissingValue {
     std::string s;
     MissingValue(std::string s): s(s) {}
@@ -353,16 +355,32 @@ template <> struct formatter<CustomValue>: public formatter<int>, formatter<stri
         return formatter<int>::format(p.val, ctx);
     }
 };
-template <> struct formatter<MissingValue>: public formatter<int>, formatter<string_view> {
+template <> struct formatter<ValidationValue> {
+    auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) {
+        return std::find(ctx.begin(), ctx.end(), '}');
+    }
+
+    template <typename FormatContext>
+    auto format(const ValidationValue &, FormatContext &ctx) -> decltype(ctx.out()) {
+        return ctx.out();
+    }
+};
+template <> struct formatter<MissingValue>: public formatter<int>, formatter<double>, formatter<string_view> {
     bool asString;
+    bool asFloat;
     auto parse(format_parse_context &ctx) -> decltype(ctx.begin()) {
         auto it = ctx.begin(), end = std::find(it, ctx.end(), '}');
         asString = true;
+        asFloat = false;
         if (it == end) return it;
         if (*(end-1) == 's') {
             return formatter<string_view>::parse(ctx);
         }
         asString = false;
+        char type = *(end-1);
+        asFloat = std::find(it, end, '.') != end || type == 'a' || type == 'A' || type == 'e' || type == 'E' || type == 'f' || type == 'F' || type == 'g' || type == 'G';
+        if (asFloat)
+            return formatter<double>::parse(ctx);
         return formatter<int>::parse(ctx);
     }
 
@@ -370,6 +388,8 @@ template <> struct formatter<MissingValue>: public formatter<int>, formatter<str
     auto format(const MissingValue &p, FormatContext &ctx) -> decltype(ctx.out()) {
         if (asString)
             return formatter<string_view>::format(p.s, ctx);
+        if (asFloat)
+            return formatter<double>::format(0.0, ctx);
         return formatter<int>::format(0, ctx);
     }
 };
@@ -404,7 +424,7 @@ std::vector<PropAccess> checkFormatString(const std::string f) {
             vformat_to(std::back_inserter(null), f, store);
         } catch (fmt::missing_arg &e) {
             std::string id = e.what();
-            store.push_back(fmt::arg(id.c_str(), CustomValue(1.0, matrixToString)));
+            store.push_back(fmt::arg(id.c_str(), ValidationValue()));
             if (std::regex_match(id, match, framePropRe)) {
                 auto clip = match[1].str(), name = match[2].str();
                 int clipi = extractClipId(clip);

--- a/text/textfilter.cpp
+++ b/text/textfilter.cpp
@@ -378,7 +378,10 @@ template <> struct formatter<MissingValue>: public formatter<int>, formatter<dou
         }
         asString = false;
         char type = *(end-1);
-        asFloat = std::find(it, end, '.') != end || type == 'a' || type == 'A' || type == 'e' || type == 'E' || type == 'f' || type == 'F' || type == 'g' || type == 'G';
+        auto precision = std::find(it, end, '.');
+        if (precision == it && precision + 1 != end && (*(precision + 1) == '<' || *(precision + 1) == '>' || *(precision + 1) == '^'))
+            precision = std::find(precision + 2, end, '.'); // Ignore a dot used as the fill character before alignment.
+        asFloat = precision != end || type == 'a' || type == 'A' || type == 'e' || type == 'E' || type == 'f' || type == 'F' || type == 'g' || type == 'G';
         if (asFloat)
             return formatter<double>::parse(ctx);
         return formatter<int>::parse(ctx);


### PR DESCRIPTION
Allows usage of `:.<n>f` suffix for specifying how many decimal places to show when using `akarin.Text`, just like in regular f-strings.

# Disclaimer

**This was made almost entirely using LLMs, under my guidance and supervision.**

Tested to be working, compiles on all platforms. However if you do not want to accept LLM code, feel free to reject this PR. I primarily did this because it was a feature I wanted personally.