### PR TITLE
Switch to nixpkgs-26.05-darwin stable branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Install Nix
         uses: cachix/install-nix-action@v31
         with:
-          nix_path: nixpkgs=channel:nixos-unstable
+          nix_path: nixpkgs=channel:nixpkgs-26.05-darwin
 
       - name: Set up Nix cache
         uses: cachix/cachix-action@v17
@@ -111,8 +111,8 @@ jobs:
 
       - name: Repair wheel
         run: |
-          nix shell .#llvm_${{ matrix.llvm }}.dist nixpkgs#uv \
-            --command uvx --from delocate delocate-wheel -v -w dist result-dist/*.whl
+          nix shell .#llvm_${{ matrix.llvm }}.dist \
+            --command nix develop --command uvx --from delocate delocate-wheel -v -w dist result-dist/*.whl
 
       - name: Upload
         uses: actions/upload-artifact@v7.0.1

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776255774,
-        "narHash": "sha256-psVTpH6PK3q1htMJpmdz1hLF5pQgEshu7gQWgKO6t6Y=",
+        "lastModified": 1783868237,
+        "narHash": "sha256-MDQLbs882ugMi408mpSwa2nw2yzN43hHtOxx0zbUcZA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "566acc07c54dc807f91625bb286cb9b321b5f42a",
+        "rev": "76fe02659c00bef75e12fbfdd45ca665115e9302",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixpkgs-26.05-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,6 @@
 {
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-26.05-darwin";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
@@ -19,6 +19,10 @@
           llvm_21 = pkgs.python3Packages.callPackage ./package.nix {libllvm = pkgs.llvmPackages_21.libllvm;};
           llvm_22 = pkgs.python3Packages.callPackage ./package.nix {libllvm = pkgs.llvmPackages_22.libllvm;};
           default = llvm_22;
+        };
+
+        devShells.default = pkgs.mkShellNoCC {
+          packages = [pkgs.uv];
         };
 
         formatter = pkgs.alejandra;


### PR DESCRIPTION
Nixpkgs 26.11 has dropped support for x86_64-darwin, so switch to the 26.05 stable branch which still has support for it.